### PR TITLE
add "extraHeaders" in opt_extraInfoSpec (Chrome >= 79)

### DIFF
--- a/listeners.js
+++ b/listeners.js
@@ -101,11 +101,11 @@ corsExt.Listeners = function() {
 
         chrome.webRequest.onHeadersReceived.addListener(response, {
             urls: state.config.urls
-        }, ['blocking', 'responseHeaders']);
+        }, ['blocking', 'responseHeaders', 'extraHeaders']);
 
         chrome.webRequest.onBeforeSendHeaders.addListener(request, {
             urls: state.config.urls
-        }, ['blocking', 'requestHeaders']);
+        }, ['blocking', 'requestHeaders', 'extraHeaders']);
 
         chrome.webRequest.onCompleted.addListener(cleanup, {
             urls: state.config.urls


### PR DESCRIPTION
I hope PR are welcome as this looks like the most maintained "[Access-Control-Allow-Origin](https://github.com/vitvad/Access-Control-Allow-Origin)" fork.
I would be very happy if you could also update the extension on [Chrome Web Store](https://chrome.google.com/webstore/detail/who-cors/hnlimanpjeeomjnpdglldcnpkppmndbp).

As per the official documentation (https://developer.chrome.com/extensions/webRequest):

> Starting from Chrome 79, request header modifications affect Cross-Origin Resource Sharing (CORS) checks. If modified headers for cross-origin requests do not meet the criteria, it will result in sending a CORS preflight to ask the server if such headers can be accepted. If you really need to modify headers in a way to violate the CORS protocol, you need to specify 'extraHeaders' in opt_extraInfoSpec. On the other hand, response header modifications do not work to deceive CORS checks. If you need to deceive the CORS protocol, you also need to specify 'extraHeaders' for the response modifications.
> 
> Starting from Chrome 79, the webRequest API does not intercept CORS preflight requests and responses by default. A CORS preflight for a request URL is visible to an extension if there is a listener with 'extraHeaders' specified in opt_extraInfoSpec for the request URL. onBeforeRequest can also take 'extraHeaders' from Chrome 79.
> 
> Starting from Chrome 79, the following request header is not provided and cannot be modified or removed without specifying 'extraHeaders' in opt_extraInfoSpec:
> Origin
> 
> Starting from Chrome 72, if you need to modify responses before Cross Origin Read Blocking (CORB) can block the response, you need to specify 'extraHeaders' in opt_extraInfpSpec.